### PR TITLE
Add talks and programme events

### DIFF
--- a/content/talks/event_cake.md
+++ b/content/talks/event_cake.md
@@ -1,0 +1,15 @@
+---
+title: "Cake 🍰"
+date: 2021-04-08T15:45:00+02:00
+talk_date: 2022-04-08T15:45:00+02:00
+talk_by: ""
+img_name: ""
+layout: ""
+remote: false
+stage: false
+twitter: ""
+description: ""
+published: true
+type: "talk"
+
+---

--- a/content/talks/event_lunch.md
+++ b/content/talks/event_lunch.md
@@ -1,0 +1,15 @@
+---
+title: "Lunch 🥪"
+date: 2021-04-08T12:05:00+02:00
+talk_date: 2022-04-08T12:05:00+02:00
+talk_by: ""
+img_name: ""
+layout: ""
+remote: false
+stage: false
+twitter: ""
+description: ""
+published: true
+type: "talk"
+
+---

--- a/content/talks/event_venue_close.md
+++ b/content/talks/event_venue_close.md
@@ -1,0 +1,15 @@
+---
+title: "Closing words 🌇"
+date: 2021-04-08T18:00:00+02:00
+talk_date: 2022-04-08T18:00:00+02:00
+talk_by: ""
+img_name: ""
+layout: ""
+remote: false
+stage: false
+twitter: ""
+description: ""
+published: true
+type: "talk"
+
+---

--- a/content/talks/event_venue_open.md
+++ b/content/talks/event_venue_open.md
@@ -1,0 +1,15 @@
+---
+title: "Venue opens 🥐"
+date: 2021-04-08T09:00:00+02:00
+talk_date: 2022-04-08T09:00:00+02:00
+talk_by: ""
+img_name: ""
+layout: ""
+remote: false
+stage: false
+twitter: ""
+description: ""
+published: true
+type: "talk"
+
+---

--- a/content/talks/event_water_break.md
+++ b/content/talks/event_water_break.md
@@ -1,0 +1,15 @@
+---
+title: "Water break"
+date: 2021-04-08T14:15:00+02:00
+talk_date: 2022-04-08T14:15:00+02:00
+talk_by: ""
+img_name: ""
+layout: ""
+remote: false
+stage: false
+twitter: ""
+description: ""
+published: true
+type: "talk"
+
+---


### PR DESCRIPTION
## This PR

* Builds on *and includes* https://github.com/django-denmark/2022.djangoday.dk/pull/16 to add "programme" events such as "venue open", "lunch break" and "cake".
* These however do not render correctly; I couldn't find a way to template these properly. However I added the templates with the correct *time* as we agreed earlier on today.
* This might need to be rebased once https://github.com/django-denmark/2022.djangoday.dk/pull/16 is merged.